### PR TITLE
Adding documentation for PUT

### DIFF
--- a/nodejs.html
+++ b/nodejs.html
@@ -141,6 +141,13 @@ When no <code>callback</code> is present, the <a href="#request">Request</a> obj
 <div class="highlight highlight-js"><pre><span class="pl-k">var</span> Request <span class="pl-k">=</span> unirest.head(<span class="pl-s"><span class="pl-pds">'</span>http://mockbin.com/request<span class="pl-pds">'</span></span>);</pre></div>
 
 <h3>
+<a id="user-content-put" class="anchor" href="#put" aria-hidden="true"><span class="octicon octicon-link"></span></a>put</h3>
+
+<p>Returns a <a href="#request">Request</a> object with the <code>method</code> option set to <code>PUT</code></p>
+
+<div class="highlight highlight-js"><pre><span class="pl-k">var</span> Request <span class="pl-k">=</span> unirest.put(<span class="pl-s"><span class="pl-pds">'</span>http://mockbin.com/request<span class="pl-pds">'</span></span>);</pre></div>
+
+<h3>
 <a id="user-content-post" class="anchor" href="#post" aria-hidden="true"><span class="octicon octicon-link"></span></a>post</h3>
 
 <p>Returns a <a href="#request">Request</a> object with the <code>method</code> option set to <code>POST</code></p>


### PR DESCRIPTION
I noticed PUT was missing from the list of HTTP verbs in the docs. Originally, I thought the library didn't support PUT requests, but then I realized it was just missing.
